### PR TITLE
fix basic test to have separate skips if no GNU tar

### DIFF
--- a/t/001Basic.t
+++ b/t/001Basic.t
@@ -132,6 +132,9 @@ SKIP: {
 
     ok(defined $f1, "numeric owner works");
 
+}
+
+SKIP: {
       # gnu options
     my $tar = Archive::Tar::Wrapper->new(
         tar_gnu_write_options => ["--exclude=foo"],


### PR DESCRIPTION
This fixes the many "You planned 24 tests but ran 23" errors on this test reported on CPANTesters.
