### PR TITLE
Some tars require a hypen at the start of the options

### DIFF
--- a/lib/Archive/Tar/Wrapper.pm
+++ b/lib/Archive/Tar/Wrapper.pm
@@ -62,6 +62,8 @@ sub new {
 
     $self->{objdir} = tempdir();
 
+    $self->{is_gnu} = $self->is_gnu();
+
     return $self;
 }
 
@@ -90,8 +92,10 @@ sub read {
     my $compr_opt = "";
     $compr_opt = $self->is_compressed($tarfile);
 
-    my $cmd = [$self->{tar}, "${compr_opt}x$self->{tar_read_options}",
-               @{$self->{tar_gnu_read_options}},
+    my $options = "${compr_opt}x$self->{tar_read_options}";
+    if (! $self->{is_gnu} ) { $options = "-$options"; }
+
+    my $cmd = [$self->{tar}, $options, @{$self->{tar_gnu_read_options}},
                "-f", $tarfile, @files];
 
     DEBUG "Running @$cmd";
@@ -417,7 +421,7 @@ sub is_gnu {
 ###########################################
     my($self) = @_;
 
-    open PIPE, "$self->{tar} --version |" or 
+    open PIPE, "$self->{tar} --version 2>/dev/null |" or 
         return 0;
 
     my $output = join "\n", <PIPE>;


### PR DESCRIPTION
This module failed tests on OpenBSD.  Example of one of the failures:

t/001Basic.t .. 1/24 2018/01/07 19:57:28 /bin/tar zx -f /home/jmaslak/git/thirdparty/archive-tar-wrapper-perl/t/data/foo.tgz failed: tar: Failed open to read on /dev/rst0: Permission denied

So, when using a non-GNU tar, this PR will enable it to execute properly.  I also silenced an error on non-GNU tar installations when calling is_gnu().

If you would like me to modify this before you would accept it, please let me know. I'm glad to adapt this PR to your wishes.